### PR TITLE
Removed client side verification

### DIFF
--- a/prover/host/src/main.rs
+++ b/prover/host/src/main.rs
@@ -69,7 +69,6 @@ async fn main() -> eyre::Result<()> {
         let proof: SP1ProofWithPublicValues = client.prove(&pk, stdin.clone()).plonk().run().expect("Proving should work.");
         println!("Proof generation finished.");
 
-        client.verify(&proof, &vk).expect("proof verification should succeed");
         // Handle the result of the save operation
         let public_values_solidity_encoded = proof.public_values.as_slice();
         let decoded_values = PublicValuesStruct::abi_decode(public_values_solidity_encoded, true).unwrap();


### PR DESCRIPTION
Removed client side proof verification after proof generation to avoid the need for 11gb sp1 circuits download.